### PR TITLE
feat(backend): implementación del CRUD de contenido

### DIFF
--- a/src/main/java/com/healthybites/api/AdminContenidoController.java
+++ b/src/main/java/com/healthybites/api/AdminContenidoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Contenido;
+import com.healthybites.service.AdminContenidoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/contenido")
+public class AdminContenidoController {
+
+    private final AdminContenidoService adminContenidoService;
+
+    @GetMapping
+    public ResponseEntity<List<Contenido>> getAllContenido() {
+        List<Contenido> contenidos = adminContenidoService.getAll();
+        return new ResponseEntity<List<Contenido>>(contenidos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Contenido>> paginateContenidos(
+            @PageableDefault(size = 5, sort = "titulo") Pageable pageable) {
+        Page<Contenido> contenidos = adminContenidoService.paginate(pageable);
+        return new ResponseEntity<Page<Contenido>>(contenidos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Contenido> getContenidoById(@PathVariable("id") Integer id) {
+        Contenido contenido = adminContenidoService.findById(id);
+        return new ResponseEntity<Contenido>(contenido, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Contenido> createContenido(@RequestBody Contenido contenido) {
+        Contenido newContenido = adminContenidoService.create(contenido);
+        return new ResponseEntity<Contenido>(newContenido, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Contenido> updateContenido(@PathVariable("id") Integer id, @RequestBody Contenido contenido) {
+        Contenido updateContenido = adminContenidoService.update(id, contenido);
+        return new ResponseEntity<Contenido>(updateContenido, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Contenido> deleteContenido(@PathVariable("id") Integer id) {
+        adminContenidoService.delete(id);
+        return new ResponseEntity<Contenido>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminGrupoController.java
+++ b/src/main/java/com/healthybites/api/AdminGrupoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Grupo;
+import com.healthybites.service.AdminGrupoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/grupo")
+public class AdminGrupoController {
+
+    private final AdminGrupoService adminGrupoService;
+
+    @GetMapping
+    public ResponseEntity<List<Grupo>> getAllGrupo() {
+        List<Grupo> grupos = adminGrupoService.getAll();
+        return new ResponseEntity<List<Grupo>>(grupos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Grupo>> paginateGrupos(
+            @PageableDefault(size = 5, sort = "nombre") Pageable pageable) {
+        Page<Grupo> grupos = adminGrupoService.paginate(pageable);
+        return new ResponseEntity<Page<Grupo>>(grupos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Grupo> getGrupoById(@PathVariable("id") Integer id) {
+        Grupo grupo = adminGrupoService.findById(id);
+        return new ResponseEntity<Grupo>(grupo, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Grupo> createGrupo(@RequestBody Grupo grupo) {
+        Grupo newGrupo = adminGrupoService.create(grupo);
+        return new ResponseEntity<Grupo>(newGrupo, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Grupo> updateGrupo(@PathVariable("id") Integer id, @RequestBody Grupo grupo) {
+        Grupo updateGrupo = adminGrupoService.update(id, grupo);
+        return new ResponseEntity<Grupo>(updateGrupo, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Grupo> deleteGrupo(@PathVariable("id") Integer id) {
+        adminGrupoService.delete(id);
+        return new ResponseEntity<Grupo>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminHabitoController.java
+++ b/src/main/java/com/healthybites/api/AdminHabitoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Habito;
+import com.healthybites.service.AdminHabitoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/habito")
+public class AdminHabitoController {
+
+    private final AdminHabitoService adminHabitoService;
+
+    @GetMapping
+    public ResponseEntity<List<Habito>> getAllHabito() {
+        List<Habito> habitos = adminHabitoService.getAll();
+        return new ResponseEntity<List<Habito>>(habitos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Habito>> paginateHabitos(
+            @PageableDefault(size = 5, sort = "nombre") Pageable pageable) {
+        Page<Habito> habitos = adminHabitoService.paginate(pageable);
+        return new ResponseEntity<Page<Habito>>(habitos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Habito> getHabitoById(@PathVariable("id") Integer id) {
+        Habito habito = adminHabitoService.findById(id);
+        return new ResponseEntity<Habito>(habito, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Habito> createHabito(@RequestBody Habito habito) {
+        Habito newHabito = adminHabitoService.create(habito);
+        return new ResponseEntity<Habito>(newHabito, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Habito> updateHabito(@PathVariable("id") Integer id, @RequestBody Habito habito) {
+        Habito updateHabito = adminHabitoService.update(id, habito);
+        return new ResponseEntity<Habito>(updateHabito, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Habito> deleteHabito(@PathVariable("id") Integer id) {
+        adminHabitoService.delete(id);
+        return new ResponseEntity<Habito>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminPagoController.java
+++ b/src/main/java/com/healthybites/api/AdminPagoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Pago;
+import com.healthybites.service.AdminPagoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/pago")
+public class AdminPagoController {
+
+    private final AdminPagoService adminPagoService;
+
+    @GetMapping
+    public ResponseEntity<List<Pago>> getAllPago() {
+        List<Pago> pagos = adminPagoService.getAll();
+        return new ResponseEntity<List<Pago>>(pagos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Pago>> paginatePagos(
+            @PageableDefault(size = 5, sort = "estado_pago") Pageable pageable) {
+        Page<Pago> pagos = adminPagoService.paginate(pageable);
+        return new ResponseEntity<Page<Pago>>(pagos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Pago> getPagoById(@PathVariable("id") Integer id) {
+        Pago pago = adminPagoService.findById(id);
+        return new ResponseEntity<Pago>(pago, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Pago> createPago(@RequestBody Pago pago) {
+        Pago newPago = adminPagoService.create(pago);
+        return new ResponseEntity<Pago>(newPago, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Pago> updatePago(@PathVariable("id") Integer id, @RequestBody Pago pago) {
+        Pago updatePago = adminPagoService.update(id, pago);
+        return new ResponseEntity<Pago>(updatePago, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Pago> deletePago(@PathVariable("id") Integer id) {
+        adminPagoService.delete(id);
+        return new ResponseEntity<Pago>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminPlanAlimenticioController.java
+++ b/src/main/java/com/healthybites/api/AdminPlanAlimenticioController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.PlanAlimenticio;
+import com.healthybites.service.AdminPlanAlimenticioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/plan-alimenticio")
+public class AdminPlanAlimenticioController {
+
+    private final AdminPlanAlimenticioService adminPlanAlimenticioService;
+
+    @GetMapping
+    public ResponseEntity<List<PlanAlimenticio>> getAllPlanAlimenticio() {
+        List<PlanAlimenticio> planAlimenticios = adminPlanAlimenticioService.getAll();
+        return new ResponseEntity<List<PlanAlimenticio>>(planAlimenticios, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<PlanAlimenticio>> paginatePlanAlimenticios(
+            @PageableDefault(size = 5, sort = "plan_objetivo") Pageable pageable) {
+        Page<PlanAlimenticio> planAlimenticios = adminPlanAlimenticioService.paginate(pageable);
+        return new ResponseEntity<Page<PlanAlimenticio>>(planAlimenticios, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PlanAlimenticio> getPlanAlimenticioById(@PathVariable("id") Integer id) {
+        PlanAlimenticio planAlimenticio = adminPlanAlimenticioService.findById(id);
+        return new ResponseEntity<PlanAlimenticio>(planAlimenticio, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<PlanAlimenticio> createPlanAlimenticio(@RequestBody PlanAlimenticio planAlimenticio) {
+        PlanAlimenticio newPlanAlimenticio = adminPlanAlimenticioService.create(planAlimenticio);
+        return new ResponseEntity<PlanAlimenticio>(newPlanAlimenticio, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PlanAlimenticio> updatePlanAlimenticio(@PathVariable("id") Integer id, @RequestBody PlanAlimenticio planAlimenticio) {
+        PlanAlimenticio updatePlanAlimenticio = adminPlanAlimenticioService.update(id, planAlimenticio);
+        return new ResponseEntity<PlanAlimenticio>(updatePlanAlimenticio, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<PlanAlimenticio> deletePlanAlimenticio(@PathVariable("id") Integer id) {
+        adminPlanAlimenticioService.delete(id);
+        return new ResponseEntity<PlanAlimenticio>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminSuscripcionController.java
+++ b/src/main/java/com/healthybites/api/AdminSuscripcionController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Suscripcion;
+import com.healthybites.service.AdminSuscripcionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/suscripcion")
+public class AdminSuscripcionController {
+
+    private final AdminSuscripcionService adminSuscripcionService;
+
+    @GetMapping
+    public ResponseEntity<List<Suscripcion>> getAllSuscripcion() {
+        List<Suscripcion> suscripcions = adminSuscripcionService.getAll();
+        return new ResponseEntity<List<Suscripcion>>(suscripcions, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Suscripcion>> paginateSuscripcion(
+            @PageableDefault(size = 5, sort = "tipo_suscripcion") Pageable pageable) {
+        Page<Suscripcion> suscripcions = adminSuscripcionService.paginate(pageable);
+        return new ResponseEntity<Page<Suscripcion>>(suscripcions, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Suscripcion> getSuscripcionById(@PathVariable("id") Integer id) {
+        Suscripcion suscripcions = adminSuscripcionService.findById(id);
+        return new ResponseEntity<Suscripcion>(suscripcions, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Suscripcion> createSuscripcion(@RequestBody Suscripcion suscripcions) {
+        Suscripcion newSuscripcion = adminSuscripcionService.create(suscripcions);
+        return new ResponseEntity<Suscripcion>(newSuscripcion, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Suscripcion> updateSuscripcion(@PathVariable("id") Integer id, @RequestBody Suscripcion suscripcion) {
+        Suscripcion updateSuscripcion = adminSuscripcionService.update(id, suscripcion);
+        return new ResponseEntity<Suscripcion>(updateSuscripcion, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Suscripcion> deleteSuscripcion(@PathVariable("id") Integer id) {
+        adminSuscripcionService.delete(id);
+        return new ResponseEntity<Suscripcion>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/repository/ContenidoRepository.java
+++ b/src/main/java/com/healthybites/repository/ContenidoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Contenido;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContenidoRepository extends JpaRepository<Contenido, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/GrupoRepository.java
+++ b/src/main/java/com/healthybites/repository/GrupoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Grupo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GrupoRepository extends JpaRepository<Grupo, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/HabitoRepository.java
+++ b/src/main/java/com/healthybites/repository/HabitoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Habito;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HabitoRepository extends JpaRepository<Habito, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/PagoRepository.java
+++ b/src/main/java/com/healthybites/repository/PagoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Pago;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PagoRepository extends JpaRepository<Pago, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/PlanAlimenticioRepository.java
+++ b/src/main/java/com/healthybites/repository/PlanAlimenticioRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.PlanAlimenticio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanAlimenticioRepository extends JpaRepository<PlanAlimenticio, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/SuscripcionRepository.java
+++ b/src/main/java/com/healthybites/repository/SuscripcionRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Suscripcion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SuscripcionRepository extends JpaRepository<Suscripcion, Integer> {
+}

--- a/src/main/java/com/healthybites/service/AdminContenidoService.java
+++ b/src/main/java/com/healthybites/service/AdminContenidoService.java
@@ -1,0 +1,16 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Contenido;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface AdminContenidoService {
+    List<Contenido> getAll();
+    Page<Contenido> paginate(Pageable pageable);
+    Contenido findById(Integer id);
+    Contenido create(Contenido contenido);
+    Contenido update(Integer id, Contenido updateContenido);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminGrupoService.java
+++ b/src/main/java/com/healthybites/service/AdminGrupoService.java
@@ -1,0 +1,16 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Grupo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface AdminGrupoService {
+    List<Grupo> getAll();
+    Page<Grupo> paginate(Pageable pageable);
+    Grupo findById(Integer id);
+    Grupo create(Grupo grupo);
+    Grupo update(Integer id, Grupo updateGrupo);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminHabitoService.java
+++ b/src/main/java/com/healthybites/service/AdminHabitoService.java
@@ -1,0 +1,16 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Habito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface AdminHabitoService {
+    List<Habito> getAll();
+    Page<Habito> paginate(Pageable pageable);
+    Habito findById(Integer id);
+    Habito create(Habito habito);
+    Habito update(Integer id, Habito updateHabito);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminPagoService.java
+++ b/src/main/java/com/healthybites/service/AdminPagoService.java
@@ -1,0 +1,16 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Pago;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface AdminPagoService {
+    List<Pago> getAll();
+    Page<Pago> paginate(Pageable pageable);
+    Pago findById(Integer id);
+    Pago create(Pago pago);
+    Pago update(Integer id, Pago updatePago);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminPlanAlimenticioService.java
+++ b/src/main/java/com/healthybites/service/AdminPlanAlimenticioService.java
@@ -1,0 +1,16 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.PlanAlimenticio;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface AdminPlanAlimenticioService {
+    List<PlanAlimenticio> getAll();
+    Page<PlanAlimenticio> paginate(Pageable pageable);
+    PlanAlimenticio findById(Integer id);
+    PlanAlimenticio create(PlanAlimenticio planAlimenticio);
+    PlanAlimenticio update(Integer id, PlanAlimenticio updatePlanAlimenticio);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminSuscripcionService.java
+++ b/src/main/java/com/healthybites/service/AdminSuscripcionService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Suscripcion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminSuscripcionService {
+    List<Suscripcion> getAll();
+    Page<Suscripcion> paginate(Pageable pageable);
+    Suscripcion findById(Integer id);
+    Suscripcion create(Suscripcion suscripcion);
+    Suscripcion update(Integer id, Suscripcion updateSuscripcion);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/impl/AdminContenidoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminContenidoServiceImpl.java
@@ -1,0 +1,62 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Contenido;
+import com.healthybites.repository.ContenidoRepository;
+import com.healthybites.service.AdminContenidoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminContenidoServiceImpl implements AdminContenidoService {
+
+    private final ContenidoRepository contenidoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Contenido> getAll() {
+        return contenidoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Contenido> paginate(Pageable pageable) {
+        return contenidoRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Contenido findById(Integer id) {
+        return contenidoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Contenido no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Contenido create(Contenido contenido) {
+        return contenidoRepository.save(contenido);
+    }
+
+    @Transactional
+    @Override
+    public Contenido update(Integer id, Contenido updateContenido) {
+        Contenido contenidoFromDB = findById(id);
+        contenidoFromDB.setTitulo(updateContenido.getTitulo());
+        contenidoFromDB.setDescripcion(updateContenido.getDescripcion());
+        contenidoFromDB.setTipoContenido(updateContenido.getTipoContenido());
+        contenidoFromDB.setCategoriaContenido(updateContenido.getCategoriaContenido());
+        contenidoFromDB.setEsGratis(updateContenido.isEsGratis());
+        return contenidoRepository.save(contenidoFromDB);
+    }
+
+    @Override
+    public void delete(Integer id) {
+        Contenido contenido = findById(id);
+        contenidoRepository.delete(contenido);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminGrupoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminGrupoServiceImpl.java
@@ -1,0 +1,61 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Grupo;
+import com.healthybites.repository.GrupoRepository;
+import com.healthybites.service.AdminClienteService;
+import com.healthybites.service.AdminGrupoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminGrupoServiceImpl implements AdminGrupoService {
+
+    private final GrupoRepository grupoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Grupo> getAll() {
+        return grupoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Grupo> paginate(Pageable pageable) {
+        return grupoRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Grupo findById(Integer id) {
+        return grupoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Grupo no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Grupo create(Grupo grupo) {
+        return grupoRepository.save(grupo);
+    }
+
+    @Transactional
+    @Override
+    public Grupo update(Integer id, Grupo updateGrupo) {
+        Grupo grupoFromDB = findById(id);
+        grupoFromDB.setNombre(updateGrupo.getNombre());
+        grupoFromDB.setEsPrivado(updateGrupo.isEsPrivado());
+        return grupoRepository.save(grupoFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Grupo grupo = findById(id);
+        grupoRepository.delete(grupo);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminHabitoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminHabitoServiceImpl.java
@@ -1,0 +1,63 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Habito;
+import com.healthybites.repository.HabitoRepository;
+import com.healthybites.service.AdminHabitoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminHabitoServiceImpl implements AdminHabitoService {
+
+    private final HabitoRepository habitoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Habito> getAll() {
+        return habitoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Habito> paginate(Pageable pageable) {
+        return habitoRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Habito findById(Integer id) {
+        return habitoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Habito no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Habito create(Habito habito) {
+        return habitoRepository.save(habito);
+    }
+
+    @Transactional
+    @Override
+    public Habito update(Integer id, Habito updateHabito) {
+        Habito habitoFromDB = findById(id);
+        habitoFromDB.setNombre(updateHabito.getNombre());
+        habitoFromDB.setHidratacion(updateHabito.getHidratacion());
+        habitoFromDB.setAlimentacion(updateHabito.getAlimentacion());
+        habitoFromDB.setEjercicio(updateHabito.getEjercicio());
+        habitoFromDB.setCalidadDeSueno(updateHabito.getCalidadDeSueno());
+        return habitoRepository.save(habitoFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Habito habito = findById(id);
+        habitoRepository.delete(habito);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminPagoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminPagoServiceImpl.java
@@ -1,0 +1,59 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Pago;
+import com.healthybites.repository.PagoRepository;
+import com.healthybites.service.AdminPagoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminPagoServiceImpl implements AdminPagoService {
+
+    private final PagoRepository pagoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Pago> getAll() {
+        return pagoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Pago> paginate(Pageable pageable) {
+        return pagoRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Pago findById(Integer id) {
+        return pagoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Pago no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Pago create(Pago pago) {
+        return pagoRepository.save(pago);
+    }
+
+    @Transactional
+    @Override
+    public Pago update(Integer id, Pago updatePago) {
+        Pago pagoFromDB = findById(id);
+        pagoFromDB.setEstadoPago(updatePago.getEstadoPago());
+        return pagoRepository.save(pagoFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Pago pago = findById(id);
+        pagoRepository.delete(pago);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminPlanAlimenticioServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminPlanAlimenticioServiceImpl.java
@@ -1,0 +1,62 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.PlanAlimenticio;
+import com.healthybites.repository.PlanAlimenticioRepository;
+import com.healthybites.service.AdminPlanAlimenticioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminPlanAlimenticioServiceImpl implements AdminPlanAlimenticioService {
+
+    private final PlanAlimenticioRepository planAlimenticioRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<PlanAlimenticio> getAll() {
+        return planAlimenticioRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<PlanAlimenticio> paginate(Pageable pageable) {
+        return planAlimenticioRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PlanAlimenticio findById(Integer id) {
+        return planAlimenticioRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Plan alimenticio no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public PlanAlimenticio create(PlanAlimenticio planAlimenticio) {
+        return planAlimenticioRepository.save(planAlimenticio);
+    }
+
+    @Transactional
+    @Override
+    public PlanAlimenticio update(Integer id, PlanAlimenticio updatePlanAlimenticio) {
+        PlanAlimenticio planAlimenticioFromDB = findById(id);
+        planAlimenticioFromDB.setPlanObjetivo(updatePlanAlimenticio.getPlanObjetivo());
+        planAlimenticioFromDB.setDescripcion(updatePlanAlimenticio.getDescripcion());
+        planAlimenticioFromDB.setDuracionDias(updatePlanAlimenticio.getDuracionDias());
+        planAlimenticioFromDB.setEsGratis(updatePlanAlimenticio.isEsGratis());
+        return planAlimenticioRepository.save(planAlimenticioFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        PlanAlimenticio planAlimenticio = findById(id);
+        planAlimenticioRepository.delete(planAlimenticio);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminSuscripcionServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminSuscripcionServiceImpl.java
@@ -1,0 +1,63 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Suscripcion;
+import com.healthybites.repository.ClienteRepository;
+import com.healthybites.repository.SuscripcionRepository;
+import com.healthybites.service.AdminSuscripcionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminSuscripcionServiceImpl implements AdminSuscripcionService {
+
+    private final SuscripcionRepository suscripcionRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Suscripcion> getAll() {
+        return suscripcionRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Suscripcion> paginate(Pageable pageable) {
+        return suscripcionRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Suscripcion findById(Integer id) {
+        return suscripcionRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Suscripcion no encontrada"));
+    }
+
+    @Transactional
+    @Override
+    public Suscripcion create(Suscripcion suscripcion) {
+        return suscripcionRepository.save(suscripcion);
+    }
+
+    @Transactional
+    @Override
+    public Suscripcion update(Integer id, Suscripcion updateSuscripcion) {
+        Suscripcion suscripcionFromDB = findById(id);
+        suscripcionFromDB.setTipoSuscripcion(updateSuscripcion.getTipoSuscripcion());
+        suscripcionFromDB.setPrecio(updateSuscripcion.getPrecio());
+        suscripcionFromDB.setFechaInicio(updateSuscripcion.getFechaInicio());
+        suscripcionFromDB.setFechaFin(updateSuscripcion.getFechaFin());
+        return suscripcionRepository.save(suscripcionFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Suscripcion suscripcion = findById(id);
+        suscripcionRepository.delete(suscripcion);
+    }
+}


### PR DESCRIPTION
Este pull request añade la implementación completa de las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) para la entidad 'Contenido'.

### Cambios Realizados

- Se añadió al repositorio 'ContenidoRepository' y con métodos básicos de CRUD.
- Se creó el servicio 'AdminContenidoService' y 'AdminContenidoServiceImpl' con la lógica de negocio para gestionar categorías.
- Se implementó el controlador 'AdminContenidoController' con endpoints REST para las operaciones CRUD.
- Se realizaron las pruebas para verificar la funcionalidad del CRUD mediante Postman.
