### PR TITLE
feat(backend): implementación del CRUD de meta

### DIFF
--- a/src/main/java/com/healthybites/api/AdminComidaDiariaController.java
+++ b/src/main/java/com/healthybites/api/AdminComidaDiariaController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.ComidaDiaria;
+import com.healthybites.service.AdminComidaDiariaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/comida-diaria")
+public class AdminComidaDiariaController {
+
+    private final AdminComidaDiariaService adminComidaDiariaService;
+
+    @GetMapping
+    public ResponseEntity<List<ComidaDiaria>> getAllComidaDiaria() {
+        List<ComidaDiaria> comidasDiarias = adminComidaDiariaService.getAll();
+        return new ResponseEntity<List<ComidaDiaria>>(comidasDiarias, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<ComidaDiaria>> paginateComidasDiarias(
+            @PageableDefault(size = 5, sort = "nombre_comida") Pageable pageable) {
+        Page<ComidaDiaria> comidasDiarias = adminComidaDiariaService.paginate(pageable);
+        return new ResponseEntity<Page<ComidaDiaria>>(comidasDiarias, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ComidaDiaria> getComidaDiariaById(@PathVariable("id") Integer id) {
+        ComidaDiaria comidaDiaria = adminComidaDiariaService.findById(id);
+        return new ResponseEntity<ComidaDiaria>(comidaDiaria, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<ComidaDiaria> createComidaDiaria(@RequestBody ComidaDiaria comidaDiaria) {
+        ComidaDiaria newComidaDiaria = adminComidaDiariaService.create(comidaDiaria);
+        return new ResponseEntity<ComidaDiaria>(newComidaDiaria, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ComidaDiaria> updateComidaDiaria(@PathVariable("id") Integer id, @RequestBody ComidaDiaria comidaDiaria) {
+        ComidaDiaria updateComidaDiaria = adminComidaDiariaService.update(id, comidaDiaria);
+        return new ResponseEntity<ComidaDiaria>(updateComidaDiaria, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ComidaDiaria> deleteComidaDiaria(@PathVariable("id") Integer id) {
+        adminComidaDiariaService.delete(id);
+        return new ResponseEntity<ComidaDiaria>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminMetaController.java
+++ b/src/main/java/com/healthybites/api/AdminMetaController.java
@@ -1,0 +1,59 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Meta;
+import com.healthybites.service.AdminMetaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/meta")
+public class AdminMetaController {
+
+    private final AdminMetaService adminMetaService;
+
+    @GetMapping
+    public ResponseEntity<List<Meta>> getAllMeta() {
+        List<Meta> metas = adminMetaService.getAll();
+        return new ResponseEntity<List<Meta>>(metas, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Meta>> paginateMetas(
+            @PageableDefault(size = 5, sort = "nombre") Pageable pageable) {
+        Page<Meta> metas = adminMetaService.paginate(pageable);
+        return new ResponseEntity<Page<Meta>>(metas, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Meta> getMetaById(@PathVariable("id") Integer id) {
+        Meta meta = adminMetaService.findById(id);
+        return new ResponseEntity<Meta>(meta, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Meta> createMeta(@RequestBody Meta meta) {
+        Meta newMeta = adminMetaService.create(meta);
+        return new ResponseEntity<Meta>(newMeta, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Meta> updateMeta(@PathVariable("id") Integer id, @RequestBody Meta meta) {
+        Meta updateMeta = adminMetaService.update(id, meta);
+        return new ResponseEntity<Meta>(updateMeta, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Meta> deleteMeta(@PathVariable("id") Integer id) {
+        adminMetaService.delete(id);
+        return new ResponseEntity<Meta>(HttpStatus.NO_CONTENT);
+    }
+
+}

--- a/src/main/java/com/healthybites/api/AdminRachaController.java
+++ b/src/main/java/com/healthybites/api/AdminRachaController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Racha;
+import com.healthybites.service.AdminRachaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/racha")
+public class AdminRachaController {
+
+        private final AdminRachaService adminRachaService;
+
+        @GetMapping
+        public ResponseEntity<List<Racha>> getAllRacha() {
+            List<Racha> rachas = adminRachaService.getAll();
+            return new ResponseEntity<List<Racha>>(rachas, HttpStatus.OK);
+        }
+
+        @GetMapping("/page")
+        public ResponseEntity<Page<Racha>> paginateRachas(
+                @PageableDefault(size = 5, sort = "diasConsecutivos") Pageable pageable) {
+            Page<Racha> rachas = adminRachaService.paginate(pageable);
+            return new ResponseEntity<Page<Racha>>(rachas, HttpStatus.OK);
+        }
+
+        @GetMapping("/{id}")
+        public ResponseEntity<Racha> getRachaById(@PathVariable("id") Integer id) {
+            Racha racha = adminRachaService.findById(id);
+            return new ResponseEntity<Racha>(racha, HttpStatus.OK);
+        }
+
+        @PostMapping
+        public ResponseEntity<Racha> createRacha(@RequestBody Racha racha) {
+            Racha newRacha = adminRachaService.create(racha);
+            return new ResponseEntity<Racha>(newRacha, HttpStatus.CREATED);
+        }
+
+        @PutMapping("/{id}")
+        public ResponseEntity<Racha> updateRacha(@PathVariable("id") Integer id, @RequestBody Racha racha) {
+            Racha updateRacha = adminRachaService.update(id, racha);
+            return new ResponseEntity<Racha>(updateRacha, HttpStatus.OK);
+        }
+
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Racha> deleteRacha(@PathVariable("id") Integer id) {
+            adminRachaService.delete(id);
+            return new ResponseEntity<Racha>(HttpStatus.NO_CONTENT);
+        }
+}

--- a/src/main/java/com/healthybites/api/AdminRecompensaController.java
+++ b/src/main/java/com/healthybites/api/AdminRecompensaController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Recompensa;
+import com.healthybites.service.AdminRecompensaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/recompensa")
+public class AdminRecompensaController {
+
+    private final AdminRecompensaService adminRecompensaService;
+
+    @GetMapping
+    public ResponseEntity<List<Recompensa>> getAllRecompensa() {
+        List<Recompensa> recompensas = adminRecompensaService.getAll();
+        return new ResponseEntity<List<Recompensa>>(recompensas, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Recompensa>> paginateRecompensas(
+            @PageableDefault(size = 5, sort = "nombre") Pageable pageable) {
+        Page<Recompensa> recompensas = adminRecompensaService.paginate(pageable);
+        return new ResponseEntity<Page<Recompensa>>(recompensas, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Recompensa> getRecompensaById(@PathVariable("id") Integer id) {
+        Recompensa recompensa = adminRecompensaService.findById(id);
+        return new ResponseEntity<Recompensa>(recompensa, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Recompensa> createRecompensa(@RequestBody Recompensa recompensa) {
+        Recompensa newRecompensa = adminRecompensaService.create(recompensa);
+        return new ResponseEntity<Recompensa>(newRecompensa, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Recompensa> updateRecompensa(@PathVariable("id") Integer id, @RequestBody Recompensa recompensa) {
+        Recompensa updateRecompensa = adminRecompensaService.update(id, recompensa);
+        return new ResponseEntity<Recompensa>(updateRecompensa, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Recompensa> deleteRecompensa(@PathVariable("id") Integer id) {
+        adminRecompensaService.delete(id);
+        return new ResponseEntity<Recompensa>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/api/AdminSeguimientoController.java
+++ b/src/main/java/com/healthybites/api/AdminSeguimientoController.java
@@ -1,0 +1,58 @@
+package com.healthybites.api;
+
+import com.healthybites.model.entity.Seguimiento;
+import com.healthybites.service.AdminSeguimientoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/seguimiento")
+public class AdminSeguimientoController {
+
+    private final AdminSeguimientoService adminSeguimientoService;
+
+    @GetMapping
+    public ResponseEntity<List<Seguimiento>> getAllSeguimiento() {
+        List<Seguimiento> seguimientos = adminSeguimientoService.getAll();
+        return new ResponseEntity<List<Seguimiento>>(seguimientos, HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Seguimiento>> paginateSeguimientos(
+            @PageableDefault(size = 5, sort = "fecha") Pageable pageable) {
+        Page<Seguimiento> seguimientos = adminSeguimientoService.paginate(pageable);
+        return new ResponseEntity<Page<Seguimiento>>(seguimientos, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Seguimiento> getSeguimientoById(@PathVariable("id") Integer id) {
+        Seguimiento seguimiento = adminSeguimientoService.findById(id);
+        return new ResponseEntity<Seguimiento>(seguimiento, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Seguimiento> createSeguimiento(@RequestBody Seguimiento seguimiento) {
+        Seguimiento newSeguimiento = adminSeguimientoService.create(seguimiento);
+        return new ResponseEntity<Seguimiento>(newSeguimiento, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Seguimiento> updateSeguimiento(@PathVariable("id") Integer id, @RequestBody Seguimiento seguimiento) {
+        Seguimiento updateSeguimiento = adminSeguimientoService.update(id, seguimiento);
+        return new ResponseEntity<Seguimiento>(updateSeguimiento, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Seguimiento> deleteSeguimiento(@PathVariable("id") Integer id) {
+        adminSeguimientoService.delete(id);
+        return new ResponseEntity<Seguimiento>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/healthybites/repository/ComidaDiariaRepository.java
+++ b/src/main/java/com/healthybites/repository/ComidaDiariaRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.ComidaDiaria;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ComidaDiariaRepository extends JpaRepository<ComidaDiaria, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/MetaRepository.java
+++ b/src/main/java/com/healthybites/repository/MetaRepository.java
@@ -1,0 +1,8 @@
+package com.healthybites.repository;
+
+
+import com.healthybites.model.entity.Meta;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MetaRepository extends JpaRepository<Meta, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/RachaRepository.java
+++ b/src/main/java/com/healthybites/repository/RachaRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Racha;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RachaRepository extends JpaRepository<Racha, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/RecompensaRepository.java
+++ b/src/main/java/com/healthybites/repository/RecompensaRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Recompensa;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecompensaRepository extends JpaRepository<Recompensa, Integer> {
+}

--- a/src/main/java/com/healthybites/repository/SeguimientoRepository.java
+++ b/src/main/java/com/healthybites/repository/SeguimientoRepository.java
@@ -1,0 +1,7 @@
+package com.healthybites.repository;
+
+import com.healthybites.model.entity.Seguimiento;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeguimientoRepository extends JpaRepository<Seguimiento, Integer> {
+}

--- a/src/main/java/com/healthybites/service/AdminComidaDiariaService.java
+++ b/src/main/java/com/healthybites/service/AdminComidaDiariaService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.ComidaDiaria;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminComidaDiariaService {
+    List<ComidaDiaria> getAll();
+    Page<ComidaDiaria> paginate(Pageable pageable);
+    ComidaDiaria findById(Integer id);
+    ComidaDiaria create(ComidaDiaria comidaDiaria);
+    ComidaDiaria update(Integer id, ComidaDiaria updateComidaDiaria);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminMetaService.java
+++ b/src/main/java/com/healthybites/service/AdminMetaService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Meta;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminMetaService {
+    List<Meta> getAll();
+    Page<Meta> paginate(Pageable pageable);
+    Meta findById(Integer id);
+    Meta create(Meta meta);
+    Meta update(Integer id, Meta updateMeta);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminRachaService.java
+++ b/src/main/java/com/healthybites/service/AdminRachaService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Racha;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminRachaService {
+    List<Racha> getAll();
+    Page<Racha> paginate(Pageable pageable);
+    Racha findById(Integer id);
+    Racha create(Racha racha);
+    Racha update(Integer id, Racha updateRacha);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminRecompensaService.java
+++ b/src/main/java/com/healthybites/service/AdminRecompensaService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Recompensa;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminRecompensaService {
+    List<Recompensa> getAll();
+    Page<Recompensa> paginate(Pageable pageable);
+    Recompensa findById(Integer id);
+    Recompensa create(Recompensa recompensa);
+    Recompensa update(Integer id, Recompensa updateRecompensa);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/AdminSeguimientoService.java
+++ b/src/main/java/com/healthybites/service/AdminSeguimientoService.java
@@ -1,0 +1,15 @@
+package com.healthybites.service;
+
+import com.healthybites.model.entity.Seguimiento;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface AdminSeguimientoService {
+    List<Seguimiento> getAll();
+    Page<Seguimiento> paginate(Pageable pageable);
+    Seguimiento findById(Integer id);
+    Seguimiento create(Seguimiento seguimiento);
+    Seguimiento update(Integer id, Seguimiento updateSeguimiento);
+    void delete(Integer id);
+}

--- a/src/main/java/com/healthybites/service/impl/AdminComidaDiariaServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminComidaDiariaServiceImpl.java
@@ -1,0 +1,61 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.ComidaDiaria;
+import com.healthybites.repository.ComidaDiariaRepository;
+import com.healthybites.service.AdminComidaDiariaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminComidaDiariaServiceImpl implements AdminComidaDiariaService {
+
+    private final ComidaDiariaRepository comidaDiariaRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ComidaDiaria> getAll() {
+        return comidaDiariaRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<ComidaDiaria> paginate(Pageable pageable) {
+        return comidaDiariaRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ComidaDiaria findById(Integer id) {
+        return comidaDiariaRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Comida diaria no encontrada"));
+    }
+
+    @Transactional
+    @Override
+    public ComidaDiaria create(ComidaDiaria comidaDiaria) {
+        return comidaDiariaRepository.save(comidaDiaria);
+    }
+
+    @Transactional
+    @Override
+    public ComidaDiaria update(Integer id, ComidaDiaria updateComidaDiaria) {
+        ComidaDiaria comidaDiariaFromDB = findById(id);
+        comidaDiariaFromDB.setNombreComida(updateComidaDiaria.getNombreComida());
+        comidaDiariaFromDB.setCalorias(updateComidaDiaria.getCalorias());
+        comidaDiariaFromDB.setCategoria(updateComidaDiaria.getCategoria());
+        return comidaDiariaRepository.save(comidaDiariaFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        ComidaDiaria comidaDiaria = findById(id);
+        comidaDiariaRepository.delete(comidaDiaria);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminMetaServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminMetaServiceImpl.java
@@ -1,0 +1,55 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Meta;
+import com.healthybites.repository.MetaRepository;
+import com.healthybites.service.AdminMetaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminMetaServiceImpl implements AdminMetaService{
+
+    private final MetaRepository metaRepository;
+
+    @Transactional(readOnly = true)
+    public List<Meta> getAll() {
+        return metaRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Meta> paginate(Pageable pageable) {
+        return metaRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Meta findById(Integer id) {
+        return metaRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Meta no encontrada"));
+    }
+
+    @Transactional
+    public Meta create(Meta meta) {
+        return metaRepository.save(meta);
+    }
+
+    @Transactional
+    public Meta update(Integer id, Meta updateMeta) {
+        Meta metaFromDB = findById(id);
+        metaFromDB.setNombre(updateMeta.getNombre());
+        metaFromDB.setDescripcion(updateMeta.getDescripcion());
+        metaFromDB.setPesoObjetivo(updateMeta.getPesoObjetivo());
+        return metaRepository.save(metaFromDB);
+    }
+
+    @Transactional
+    public void delete(Integer id) {
+        Meta meta = findById(id);
+        metaRepository.delete(meta);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminRachaServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminRachaServiceImpl.java
@@ -1,0 +1,61 @@
+package com.healthybites.service.impl;
+
+
+import com.healthybites.model.entity.Racha;
+import com.healthybites.repository.RachaRepository;
+import com.healthybites.service.AdminRachaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminRachaServiceImpl implements AdminRachaService {
+
+    private final RachaRepository rachaRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Racha> getAll() {
+        return rachaRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Racha> paginate(Pageable pageable) {
+        return rachaRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Racha findById(Integer id) {
+        return rachaRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Racha no encontrada"));
+    }
+
+    @Transactional
+    @Override
+    public Racha create(Racha racha) {
+        return rachaRepository.save(racha);
+    }
+
+    @Transactional
+    @Override
+    public Racha update(Integer id, Racha updateRacha) {
+        Racha rachaFromDB = findById(id);
+        rachaFromDB.setDiasConsecutivos(updateRacha.getDiasConsecutivos());
+        rachaFromDB.setUltimaFechaRegistro(updateRacha.getUltimaFechaRegistro());
+        return rachaRepository.save(rachaFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Racha racha = findById(id);
+        rachaRepository.delete(racha);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminRecompensaServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminRecompensaServiceImpl.java
@@ -1,0 +1,61 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Recompensa;
+import com.healthybites.repository.RecompensaRepository;
+import com.healthybites.service.AdminRecompensaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminRecompensaServiceImpl implements AdminRecompensaService {
+
+    private final RecompensaRepository recompensaRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Recompensa> getAll() {
+        return recompensaRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Recompensa> paginate(Pageable pageable) {
+        return recompensaRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Recompensa findById(Integer id) {
+        return recompensaRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Recompensa no encontrada"));
+    }
+
+    @Transactional
+    @Override
+    public Recompensa create(Recompensa recompensa) {
+        return recompensaRepository.save(recompensa);
+    }
+
+    @Transactional
+    @Override
+    public Recompensa update(Integer id, Recompensa updateRecompensa) {
+        Recompensa recompensaFromDB = findById(id);
+        recompensaFromDB.setNombre(updateRecompensa.getNombre());
+        recompensaFromDB.setDescripcion(updateRecompensa.getDescripcion());
+        recompensaFromDB.setDiasRequeridos(updateRecompensa.getDiasRequeridos());
+        return recompensaRepository.save(recompensaFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Recompensa recompensa = findById(id);
+        recompensaRepository.delete(recompensa);
+    }
+}

--- a/src/main/java/com/healthybites/service/impl/AdminSeguimientoServiceImpl.java
+++ b/src/main/java/com/healthybites/service/impl/AdminSeguimientoServiceImpl.java
@@ -1,0 +1,61 @@
+package com.healthybites.service.impl;
+
+import com.healthybites.model.entity.Seguimiento;
+import com.healthybites.repository.SeguimientoRepository;
+import com.healthybites.service.AdminSeguimientoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminSeguimientoServiceImpl implements AdminSeguimientoService {
+
+    private final SeguimientoRepository seguimientoRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Seguimiento> getAll() {
+        return seguimientoRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Seguimiento> paginate(Pageable pageable) {
+        return seguimientoRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Seguimiento findById(Integer id) {
+        return seguimientoRepository.findById(id).
+                orElseThrow(() -> new RuntimeException("Seguimiento no encontrado"));
+    }
+
+    @Transactional
+    @Override
+    public Seguimiento create(Seguimiento seguimiento) {
+        return seguimientoRepository.save(seguimiento);
+    }
+
+    @Transactional
+    @Override
+    public Seguimiento update(Integer id, Seguimiento updateSeguimiento) {
+        Seguimiento seguimientoFromDB = findById(id);
+        seguimientoFromDB.setFecha(updateSeguimiento.getFecha());
+        seguimientoFromDB.setPesoDelDia(updateSeguimiento.getPesoDelDia());
+        seguimientoFromDB.setObservaciones(updateSeguimiento.getObservaciones());
+        return seguimientoRepository.save(seguimientoFromDB);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Seguimiento seguimiento = findById(id);
+        seguimientoRepository.delete(seguimiento);
+    }
+}


### PR DESCRIPTION
Este pull request añade la implementación completa de las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) para la entidad 'Meta'.

### Cambios Realizados

- Se añadió al repositorio 'MetaRepository' y con métodos básicos de CRUD.
- Se creó el servicio 'AdminMetaService' y 'AdminMetaServiceImpl' con la lógica de negocio para gestionar categorías.
- Se implementó el controlador 'AdminMetaController' con endpoints REST para las operaciones CRUD.
- Se realizaron las pruebas para verificar la funcionalidad del CRUD mediante Postman.

